### PR TITLE
Keep css extension

### DIFF
--- a/css-builder.js
+++ b/css-builder.js
@@ -128,8 +128,6 @@ define(['require', './normalize'], function(req, normalize) {
   cssAPI.normalize = function(name, normalize) {
     if (name.substr(name.length - 1, 1) == '!')
       name = name.substr(0, name.length - 1);
-    if (name.substr(name.length - 4, 4) == '.css')
-      name = name.substr(0, name.length - 4);
     return normalize(name);
   }
   


### PR DESCRIPTION
By keeping the extension, the css plugin can be added to the stubModules r.js definition.

The current solution strips the .css extension, generating the following output:

``` js
define('css!Application/assets/css/app',[],function(){});
```

Then if a module requires this dep as follows:

``` js
    'css!./assets/css/app.css'
```

require/almond will request the css plugin to fetch the module.
This works fine, but the css plugin must be in the source for this to work. This means it can't be stubbed.

This fixes the issue because, by keeping the extension, require/almond know that the module is already defined and will not hit the css plugin.
