### PR TITLE
Normalize URIs before parsing CSS

### DIFF
--- a/css.js
+++ b/css.js
@@ -129,8 +129,6 @@ define(['./normalize'], function(normalize) {
     //internal url -> download and inject into <style> tag
     else {
       get(fileUrl, function(css) {
-        if (parse)
-          css = parse(css);
           
         var pathname = window.location.pathname.split('/');
         pathname.pop();
@@ -141,6 +139,9 @@ define(['./normalize'], function(normalize) {
           fileUrl = '/' + normalize.convertURIBase(fileUrl, pathname, '/');
         
         css = normalize(css, fileUrl, pathname);
+
+        if (parse)
+          css = parse(css);
 
         cssAPI.inject(css);
           


### PR DESCRIPTION
Moved parse fn to after normalize fn to ensure that parsed CSS has normalized URI's. This fixes the issue in require-less where the LESS parser was trying to import CSS before normalize had a chance to correct the import statement URIs. 
