### PR TITLE
Fix incorrect normalize path in optimized output

### DIFF
--- a/css-builder.js
+++ b/css-builder.js
@@ -184,7 +184,7 @@ define(['require', './normalize'], function(req, normalize) {
       css = escape(compress(css));
       
       //derive the absolute path for the normalize helper
-      var normalizeName = normalize.convertURIBase('normalize.js', req.toUrl('./normalize.js'), require.toUrl('.'));
+      var normalizeName = normalize.convertURIBase('normalize', req.toUrl('./normalize.js'), require.toUrl('.'));
       
       //the code below overrides async require functionality to ensure instant layer css injection
       //it then runs normalization and injection


### PR DESCRIPTION
Optimized output included a require(['css', 'path/to/normalize.js', ...]) call.

The .js suffix causes the RequireJS base URL to be ignored when loading the normalize module (and instead tries to load it by appending path/to/normalize.js directly to the page URL).

This change fixes the issue for me, though there may be a more appropriate place to put it :)
