### PR TITLE
Don't remove double slashes from data URIs

### DIFF
--- a/normalize.js
+++ b/normalize.js
@@ -41,6 +41,8 @@ define(['require', 'module'], function(require, module) {
 
   // given a relative URI, and two absolute base URIs, convert it from one base to another
   function convertURIBase(uri, fromBase, toBase) {
+    if(uri.indexOf("data:") === 0)
+      return uri;
     uri = removeDoubleSlashes(uri);
     // absolute urls are left in tact
     if (uri.match(/^\/|([^\:\/]*:)/))


### PR DESCRIPTION
I'm not so sure if this is the best way to do it. 
I also thought about calling the `removeDoubleSlashes()` after testing for absolute URLs but then double slashes from absolute URLs wouldn't be removed.
