### PR TITLE
Added regex to check for absolute fileUrls before adding preceding slash

### DIFF
--- a/css.js
+++ b/css.js
@@ -333,7 +333,8 @@ define(['./normalize'], function(normalize) {
   var loadCSS = function(fileUrl, callback, errback) {
 
     //make file url absolute
-    if (fileUrl.substr(0, 1) != '/')
+    var pat = /^(https?:\/)?\//i;
+    if (!pat.test(fileUrl))
       fileUrl = '/' + normalize.convertURIBase(fileUrl, pathname, '/');
 
     get(fileUrl, function(css) {


### PR DESCRIPTION
When using require-less in combination with require-css and with absolute urls, the "make url absolute" method in css.js ads a slash preceding "http" in the url. I added a regex pattern that checks if fileUrl begins with either "/" or "http(s)" before adding a slash. 
