### PR TITLE
CDN: Fix for // urls and check itself moved to function isRemote

### DIFF
--- a/css-builder.js
+++ b/css-builder.js
@@ -167,7 +167,7 @@ define(['require', './normalize'], function(req, normalize) {
     var fileUrl = req.toUrl(name);
 
     //external URLS don't get added (just like JS requires)
-    if (fileUrl.substr(0, 7) == 'http://' || fileUrl.substr(0, 8) == 'https://')
+    if (cssAPI.isRemote(fileUrl))
       return load();
 
     //add to the buffer
@@ -178,6 +178,10 @@ define(['require', './normalize'], function(req, normalize) {
       _cssBuffer[name] = parse(_cssBuffer[name]);
 
     load();
+  }
+
+  cssAPI.isRemote=function(url){
+    return (url.substr(0, 7) == 'http://' || url.substr(0, 8) == 'https://' || url.substr(0, 2) == '//')
   }
   
   cssAPI.normalize = function(name, normalize) {
@@ -191,7 +195,7 @@ define(['require', './normalize'], function(req, normalize) {
   var _cssBuffer = [];
   cssAPI.write = function(pluginName, moduleName, write, parse) {
     //external URLS don't get added (just like JS requires)
-    if (moduleName.substr(0, 7) == 'http://' || moduleName.substr(0, 8) == 'https://' || moduleName.substr(0, 2) == '//')
+    if (cssAPI.isRemote(moduleName))
       return;
     
     var resourceName = moduleName + (!parse ? '.css' : '.less');


### PR DESCRIPTION
Did not work previously with CDN url starting with "//", like:

css!//ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/themes/ui-lightness/jquery-ui.min
