### PR TITLE
fix an error in the regex urlRegEx

### DIFF
--- a/normalize.js
+++ b/normalize.js
@@ -114,7 +114,7 @@ define(['require', 'module'], function(require, module) {
     fromBase = removeDoubleSlashes(fromBase);
     toBase = removeDoubleSlashes(toBase);
 
-    var urlRegEx = /@import\s*("([^"]*)"|'([^']*)')|url\s*\(\s*(\s*"([^"]*)"|'([^']*)'|[^\)]*\s*)\s*\)/ig;
+    var urlRegEx = /@import\s*((?:"([^"]*)")|(?:'([^']*)'))|url\s*\(\s*(\s*(?:"([^"]*)")|(?:'([^']*)')|[^\)]*\s*)\s*\)/ig;
     var result, url, source;
 
     while (result = urlRegEx.exec(source)) {


### PR DESCRIPTION
This error fixes a precedence error in the regex. The old version did not account for the weak binding of |
