### PR TITLE
improve error reporting reducing the `try` extent

### DIFF
--- a/css-builder.js
+++ b/css-builder.js
@@ -5,15 +5,15 @@ define(['require', './normalize'], function(req, normalize) {
     if (typeof process !== "undefined" && process.versions && !!process.versions.node && require.nodeRequire) {
       try {
         var csso = require.nodeRequire('csso');
-        var csslen = css.length;
-        css = csso.justDoIt(css);
-        console.log('Compressed CSS output to ' + Math.round(css.length / csslen * 100) + '%.');
-        return css;
       }
       catch(e) {
         console.log('Compression module not installed. Use "npm install csso -g" to enable.');
         return css;
       }
+      var csslen = css.length;
+      css = csso.justDoIt(css);
+      console.log('Compressed CSS output to ' + Math.round(css.length / csslen * 100) + '%.');
+      return css;
     }
     console.log('Compression not supported outside of nodejs environments.');
     return css;


### PR DESCRIPTION
Hi, with this pull request i propose to reduce the extent of a `try` branch.

The current code was misleading for me. An error in CSS was reported as "module not installed". You may want to add another try catch, but it may mask errors coming from the optimizer. In my case i got a line number from the exception thrown inside `justDoIt`, and although it was false, i wouldn't like to mask it. I was able to reproduce the same error manually running `csso` on the concatenated file, and seeing the match helped me to know i was going in the right direction.
