### PR TITLE
Error when absolute paths include the protocol

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -69,6 +69,11 @@ requirejs(['../css', '../normalize'], function(css, normalize) {
     '//font.server.com/static/fonts/opensans.woff'
   );
   assert(
+    'absolute url convert base',
+    normalize.convertURIBase("http://font.server.com/static/fonts/opensans.woff", '/first/one/', '/second/one/'),
+    'http://font.server.com/static/fonts/opensans.woff'
+  );
+  assert(
     'multiple url includes on the same line',
     normalize('src: url("../fonts/font.eot") format("embedded-opentype"), url("../fonts/font.woff") format("woff");', '/base/', '/'),
     'src: url("fonts/font.eot") format("embedded-opentype"), url("fonts/font.woff") format("woff");'


### PR DESCRIPTION
A colleague reminded me that #113 can fail in a very simple case, when a protocol is specified. Inside `normalize.js` you already detect absolute paths with a protocol, so instead of adding conditions inside the `if` you probably will want to generalize this in a function.

I don't have time now to propose a clean solution. I would just leave this failing test case and this pull request here, in order to help anybody that could have this problem in the future.
