### PR TITLE
(fix #141) Allow the css plugin to be excluded in production using pragmasOnSave

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,11 @@ The RequireJS Optimizer Configuration for this is:
 
 ```javascript
 {
-  stubModules: ['require-css'],
+  pragmasOnSave: {
+    excludeRequireCss: true
+  }
 }
 ```
-
-An exclude to `require-css/normalize` can also be added to the module or layer as well.
 
 ### siteRoot Configuration
 

--- a/css.js
+++ b/css.js
@@ -31,6 +31,7 @@
  */
 
 define(function() {
+//>>excludeStart('excludeRequireCss', pragmas.excludeRequireCss)
   if (typeof window == 'undefined')
     return { load: function(n, r, load){ load() } };
 
@@ -54,9 +55,11 @@ define(function() {
   else if (engine[4])
     useImportLoad = parseInt(engine[4]) < 18;
   
+//>>excludeEnd('excludeRequireCss')
   //main api object
   var cssAPI = {};
-  
+
+//>>excludeStart('excludeRequireCss', pragmas.excludeRequireCss)
   cssAPI.pluginBuilder = './css-builder';
 
   // <style> @import load method
@@ -145,18 +148,21 @@ define(function() {
     head.appendChild(link);
   }
 
+//>>excludeEnd('excludeRequireCss')
   cssAPI.normalize = function(name, normalize) {
     if (name.substr(name.length - 4, 4) == '.css')
       name = name.substr(0, name.length - 4);
-    
+
     return normalize(name);
   }
-  
+
+//>>excludeStart('excludeRequireCss', pragmas.excludeRequireCss)
   cssAPI.load = function(cssId, req, load, config) {
 
     (useImportLoad ? importLoad : linkLoad)(req.toUrl(cssId + '.css'), load);
 
   }
 
+//>>excludeEnd('excludeRequireCss')
   return cssAPI;
 });

--- a/normalize.js
+++ b/normalize.js
@@ -1,3 +1,4 @@
+//>>excludeStart('excludeRequireCss', pragmas.excludeRequireCss)
 /*
  * css.normalize.js
  *
@@ -137,3 +138,4 @@ define(function() {
   
   return normalizeCSS;
 });
+//>>excludeEnd('excludeRequireCss')


### PR DESCRIPTION
Use the pragmasOnSave below to exclude plugin code in production.

``` javascript
pragmasOnSave: {
  excludeRequireCss: true
}
```

Fixes #141
