### PR TITLE
Fix "TypeError: Cannot call method 'replace' of undefined" error

### DIFF
--- a/css-builder.js
+++ b/css-builder.js
@@ -149,7 +149,7 @@ define(['require', './normalize'], function(req, normalize) {
   cssAPI.onLayerEnd = function(write, data) {
     //calculate layer css
     var css = layerBuffer.join('');
-    var outPath = config.appDir ? config.baseUrl + data.name + '.css' : config.out.replace(/(\.js)?$/, '.css');
+    var outPath = config.dir ? config.baseUrl + data.name + '.css' : config.out.replace(/(\.js)?$/, '.css');
     
     if (config.separateCSS) {
       console.log('Writing CSS! file: ' + data.name + '\n');


### PR DESCRIPTION
...when using "modules" and "dir" settings in the r.js build file.

Originally `css-builder.js` check for `config.appDir` settings in the build file. If it doesn't exist, use `config.out` as the output path. Otherwise, use `config.baseUrl` as the parent directory.

However, that kind of check is just wrong. According to the [document](https://github.com/jrburke/r.js/blob/master/build/example.build.js), `appDir` is optional. What really needs to check is the `dir` option, which must be used together with `modules`.
