### PR TITLE
Fix single file builds.

### DIFF
--- a/css-builder.js
+++ b/css-builder.js
@@ -1,6 +1,6 @@
 define(['require', './normalize'], function(req, normalize) {
   var cssAPI = {};
-  
+
   var isWindows = !!process.platform.match(/^win/);
 
   function compress(css) {
@@ -26,7 +26,7 @@ define(['require', './normalize'], function(req, normalize) {
     console.log('Compression not supported outside of nodejs environments.');
     return css;
   }
-  
+
   //load file code - stolen from text plugin
   function loadFile(path) {
     if (typeof process !== "undefined" && process.versions && !!process.versions.node && require.nodeRequire) {
@@ -57,8 +57,8 @@ define(['require', './normalize'], function(req, normalize) {
       }
     }
   }
-  
-  
+
+
   function saveFile(path, data) {
     if (typeof process !== "undefined" && process.versions && !!process.versions.node && require.nodeRequire) {
       var fs = require.nodeRequire('fs');
@@ -67,7 +67,7 @@ define(['require', './normalize'], function(req, normalize) {
     else {
       var content = new java.lang.String(data);
       var output = new java.io.BufferedWriter(new java.io.OutputStreamWriter(new java.io.FileOutputStream(path), 'utf-8'));
-  
+
       try {
         output.write(content, 0, content.length());
         output.flush();
@@ -77,7 +77,7 @@ define(['require', './normalize'], function(req, normalize) {
       }
     }
   }
-  
+
   //when adding to the link buffer, paths are normalised to the baseUrl
   //when removing from the link buffer, paths are normalised to the output file path
   function escape(content) {
@@ -99,7 +99,7 @@ define(['require', './normalize'], function(req, normalize) {
   var baseParts = req.toUrl('base_url').split('/');
   baseParts[baseParts.length - 1] = '';
   var baseUrl = baseParts.join('/');
-  
+
   var curModule = 0;
   var config;
 
@@ -128,33 +128,31 @@ define(['require', './normalize'], function(req, normalize) {
 
     load();
   }
-  
+
   cssAPI.normalize = function(name, normalize) {
     if (name.substr(name.length - 4, 4) == '.css')
       name = name.substr(0, name.length - 4);
     return normalize(name);
   }
-  
+
   cssAPI.write = function(pluginName, moduleName, write, parse) {
     //external URLS don't get added (just like JS requires)
     if (moduleName.match(absUrlRegEx))
       return;
 
     layerBuffer.push(cssBuffer[moduleName]);
-    
+
     if (config.buildCSS != false)
     write.asModule(pluginName + '!' + moduleName, 'define(function(){})');
   }
-  
+
   cssAPI.onLayerEnd = function(write, data) {
     if (config.separateCSS && config.IESelectorLimit)
       throw 'RequireCSS: separateCSS option is not compatible with ensuring the IE selector limit';
 
     if (config.separateCSS) {
-      console.log('Writing CSS! file: ' + data.name + '\n');
-
-      fs.mkdirSync(data.name)
-      var outPath = config.dir ? path.resolve(config.dir, config.baseUrl, data.name + '.css') : config.out.replace(/(\.js)?$/, '.css');
+      var outPath = data.path.replace(/(\.js)?$/, '.css');
+      console.log('Writing CSS! file: ' + outPath + '\n');
 
       var css = layerBuffer.join('');
 
@@ -162,9 +160,9 @@ define(['require', './normalize'], function(req, normalize) {
         console.log('RequireCSS: Warning, separateCSS module path "' + outPath + '" already exists and is being replaced by the layer CSS.');
 
       process.nextTick(function() {
-        saveFile(outPath, compress(css));  
+        saveFile(outPath, compress(css));
       });
-      
+
     }
     else if (config.buildCSS != false) {
       var styles = config.IESelectorLimit ? layerBuffer : [layerBuffer.join('')];
@@ -174,12 +172,12 @@ define(['require', './normalize'], function(req, normalize) {
         write(
           "(function(c){var d=document,a='appendChild',i='styleSheet',s=d.createElement('style');s.type='text/css';d.getElementsByTagName('head')[0][a](s);s[i]?s[i].cssText=c:s[a](d.createTextNode(c));})\n"
           + "('" + escape(compress(styles[i])) + "');\n"
-        );        
+        );
       }
-    }    
+    }
     //clear layer buffer for next layer
     layerBuffer = [];
   }
-  
+
   return cssAPI;
 });


### PR DESCRIPTION
The recent changes broke single output file builds. Version `0.1.2` worked fine. After some debugging, the culprit is https://github.com/guybedford/require-css/commit/ba7680c04f9bb27cdcc38a9b11b0f7f63b5b8cf0

The "data" object contains a "path" property containing the full path of the output file (already normalised) for both single and multiple files. Having this said, there's no need to check for `config.dir`.
Also the `mkdirSync` is unnecessary because requirejs already creates the output directory.

Cleaned leading/trailing whitespaces
