### PR TITLE
Fix the file url to be based always in the output directory

### DIFF
--- a/css-builder.js
+++ b/css-builder.js
@@ -126,7 +126,7 @@ define(['require', './normalize'], function(req, normalize) {
       fileUrl = fileUrl.replace(/\\/g, '/');
 
     // rebase to the output directory if based on the source directory;
-    // baseUrl points always to the ouptut directory, fileUrl only if
+    // baseUrl points always to the output directory, fileUrl only if
     // it is not prefixed by a computed path (relative too)
     var fileSiteUrl = fileUrl;
     if (fileSiteUrl.indexOf(baseUrl) < 0) {


### PR DESCRIPTION
If the module ID (path) starts with a prefix defined in the require path configuration, the result of the toUrl is based in the input directory  If the file needs to be processed from the output directory, which is the usual case, the path has to be rebased.
