### PR TITLE
Non-blocking CSS loading

### DIFF
--- a/css.js
+++ b/css.js
@@ -128,9 +128,11 @@ define(function() {
     var link = document.createElement('link');
     link.type = 'text/css';
     link.rel = 'stylesheet';
+    link.media = 'only x';
     if (useOnload)
       link.onload = function() {
         link.onload = function() {};
+        link.media = 'all';
         // for style dimensions queries, a short delay can still be necessary
         setTimeout(callback, 7);
       }
@@ -140,6 +142,7 @@ define(function() {
           var sheet = document.styleSheets[i];
           if (sheet.href == link.href) {
             clearInterval(loadInterval);
+            link.media = 'all';
             return callback();
           }
         }


### PR DESCRIPTION
By default CSS files loaded through `<link>` tags are downloaded synchronous, while an asynchronous approach would be preferred. 

By setting the media attribute of the link tag to a non-matching item the browser will treat it as non-blocking, making the request async. Once the CSS has been loaded the media attribute is reset to `all` so it will match and the CSS will get applied.

This is based on information found at: https://gist.github.com/scottjehl/87176715419617ae6994
