### PR TITLE
Fixes #176 by adding css-specific "optimize" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,15 +218,11 @@ CSS requires will then be left in the source "as is". This shouldn't be used wit
 
 ### Disabling CSS Optimization
 
-To disable CSS optimization of the built CSS, use the `optimize` option:
+To disable CSS optimization of the built CSS, use the `optimizeRequireCSS` option:
 
 ```javascript
 {
-  config: {
-    'css': {
-      optimize: false
-    }
-  },
+  optimizeRequireCSS: false,
   modules: [
   {
     name: 'mymodule'

--- a/css-builder.js
+++ b/css-builder.js
@@ -4,7 +4,7 @@ define(['require', './normalize'], function(req, normalize) {
   var isWindows = !!process.platform.match(/^win/);
 
   function compress(css) {
-    if (cssConfig.optimize===false) {
+    if (config.optimizeRequireCSS===false) {
       return css;
     }
     
@@ -108,7 +108,6 @@ define(['require', './normalize'], function(req, normalize) {
 
   var curModule = 0;
   var config;
-  var cssConfig;
 
   var writeCSSForLayer = true;
   var layerBuffer = [];
@@ -117,7 +116,6 @@ define(['require', './normalize'], function(req, normalize) {
   cssAPI.load = function(name, req, load, _config) {
     //store config
     config = config || _config;
-    cssConfig = (config.config && config.config.css) ? config.config.css : {};
 
     if (!siteRoot) {
       siteRoot = path.resolve(config.dir || path.dirname(config.out), config.siteRoot || '.') + '/';


### PR DESCRIPTION
Removed the dependency on requirejs's optimizeCss option and introduced a css-specific option which can disable optimization, defaulting to true.  I added this under requirejs's "config" option which allows module-specific options without polluting the "global" config thinking that's the least intrusive option going forward, but happy to change that if desired.

Let me know if anything is amiss.

UPD, by @alundiak: This is try to fix issue #176