### PR TITLE
fix wrong path conversion

### DIFF
--- a/normalize.js
+++ b/normalize.js
@@ -43,10 +43,25 @@ define(function() {
   // given a relative URI, and two absolute base URIs, convert it from one base to another
   var protocolRegEx = /[^\:\/]*:\/\/([^\/])*/;
   var absUrlRegEx = /^(\/|data:)/;
+
+  // given a URI, remove '..' if possible
+  function normalizeURI(uri) {
+      return removeDoubleSlashes(uri).split('/').reduce(function(prev, curr, idx) {
+          if (prev.length === 0 || curr !== '..') {
+              prev.push(curr);
+          } else {
+              prev.pop();
+          }
+          return prev;
+      }, []).join('/');
+  }
+
   function convertURIBase(uri, fromBase, toBase) {
+    fromBase = normalizeURI(fromBase);
+    toBase = normalizeURI(toBase);
     if (uri.match(absUrlRegEx) || uri.match(protocolRegEx))
       return uri;
-    uri = removeDoubleSlashes(uri);
+    uri = normalizeURI(uri);
     // if toBase specifies a protocol path, ensure this is the same protocol as fromBase, if not
     // use absolute path at fromBase
     var toBaseProtocol = toBase.match(protocolRegEx);
@@ -111,11 +126,8 @@ define(function() {
     
     return out.substr(0, out.length - 1);
   };
-  
-  var normalizeCSS = function(source, fromBase, toBase) {
 
-    fromBase = removeDoubleSlashes(fromBase);
-    toBase = removeDoubleSlashes(toBase);
+  var normalizeCSS = function(source, fromBase, toBase) {
 
     var urlRegEx = /@import\s*("([^"]*)"|'([^']*)')|url\s*\((?!#)\s*(\s*"([^"]*)"|'([^']*)'|[^\)]*\s*)\s*\)/ig;
     var result, url, source;

--- a/test/test.js
+++ b/test/test.js
@@ -47,6 +47,11 @@ requirejs(['../css', '../normalize'], function(css, normalize) {
     normalize.convertURIBase('some/file', 'http://some.cdn.com/baseUrl/', 'baseUrl/'),
     'http://some.cdn.com/baseUrl/some/file'
   );
+  assert(
+    'Converting with backtrack in fromBase',
+    normalize.convertURIBase('url(../test)', '/one/two/../three', '/one/four'),
+    'url(../test)'
+  );
   console.log('\nTesting Stylesheet Regular Expressions');
   assert(
     '@import statements',


### PR DESCRIPTION
# Problem

when fromBase or toBase contain backtracks, result of path conversion will
be incoorect.

e.g:

when basePath is `src/app`, in js file `src/util/util.js` we
require `../style.css`:

**util.js**

```
  define(['../style.less'], function () {});
```

the css file contains a reference to an img or something:

**style.css**

```
  .foo{
    background-image: url(../img/bg.png);
  }
```

when building the whole app as one .js, after normalizing, in the js the url
is incorrect. Because outPath is `baseUrl + filePath` in this case
`src/app/../util/util.js` and in `absoluteURI()` it treat `'..'` as normal
path part, which cause the wrong result.
# Solution

"normalize" `fromBase` and `toBase` in the very begining of `normalizeCSS` function.

A test is added to reveal the bug on the edge case, it will be failed before applying
the patch, and will pass after applying it.
