### PR TITLE
csso changes.

### DIFF
--- a/css-builder.js
+++ b/css-builder.js
@@ -18,7 +18,7 @@ define(['require', './normalize'], function(req, normalize) {
       }
       var csslen = css.length;
       try {
-        css =  csso.justDoIt(css);
+        css =  csso.minify(css);
       }
       catch(e) {
         console.log('Compression failed due to a CSS syntax error.');


### PR DESCRIPTION
`csso.justDoIt()` method is deprecated, use `csso.minify()` instead
