### PR TITLE
Replaced 'csso.justDoIt()' by `csso.minify()`

### DIFF
--- a/css-builder.js
+++ b/css-builder.js
@@ -18,7 +18,7 @@ define(['require', './normalize'], function(req, normalize) {
       }
       var csslen = css.length;
       try {
-        css =  csso.justDoIt(css);
+        css =  csso.minify(css);
       }
       catch(e) {
         console.log('Compression failed due to a CSS syntax error.');


### PR DESCRIPTION
I have such error (based on requirecss 0.1.8 and csso 1.5.3 and even 1.8.1)
```
`csso.justDoIt()` method is deprecated, use `csso.minify()` instead
Compressed CSS output to 82%.
```

And according csso release info in csso 2.0.0 they dropped `justDoIt()` at all.

So this change is about to use `csso.minify()` and with further new 0.1.9 version of requirecss.

tested with local code in scope of my project - no error then.

Btw, I also tested with csso v 2.3.0, where initially I had and warning 
```
[TypeError: csso.justDoIt is not a function]
Compression failed due to a CSS syntax error.
```
So after usage `csso.minify()` no warning.
