### PR TITLE
declare main file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,5 +3,6 @@
   "version": "0.1.8",
   "volo": {
     "type": "directory"
-  }
+  },
+  "main": "css.min.js"
 }


### PR DESCRIPTION
Hello and thanks for your awesome module !

For automation, I'd need it to declare its main file as a standard npm package (or else I have to enter it manually in some tooling)

Do you approve ?