### PR TITLE
Small dev. changes [.gitignore, package.json, .editorconfig, .jsbeautifyrc]

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 example/www-built
+node_modules
+bower_components
+*.log
+*.DS_Store

--- a/.jsbeautifyrc
+++ b/.jsbeautifyrc
@@ -1,0 +1,6 @@
+{
+  "js": {
+    "indent_char": " ",
+    "indent_size": 2
+  }
+}

--- a/bower.json
+++ b/bower.json
@@ -2,5 +2,5 @@
   "name": "require-css",
   "version": "0.1.9",
   "ignore": ["example", "test", ".gitignore"],
-  "main": ["css.js", "css-builder.js", "normalize.js"]
+  "main": ["css.js"]
 }

--- a/example/build.js
+++ b/example/build.js
@@ -2,7 +2,7 @@
   appDir: 'www',
   dir: 'www-built',
   baseUrl: '.',
-  fileExclusionRegExp: /(^example)|(.git)$/,
+  fileExclusionRegExp: /(^example)|(.git)|(node_modules)|(bower_components)$/,
   //separateCSS: true,
   //buildCSS: false,
   optimizeCss: "none",

--- a/package.json
+++ b/package.json
@@ -3,5 +3,8 @@
   "version": "0.1.9",
   "volo": {
     "type": "directory"
+  },
+  "scripts": {
+    "test": "node test/test.js"
   }
 }


### PR DESCRIPTION
1) Even, require-css doesn't have devDependencies (so far, maybe in future something changed), we better to ignore `node_modules` and `bower_components`. This is valuable at least for use case, mentioned in README.md file in regards to installing csso locally and running `npm test` which requires local requirejs. Also ignored `DS_Strore` and `.log`

2) During command `r.js -o example/build.js` it's also checking node_modules and bower_components folders, if such exists. So I added to exclude pattern in `example/build.js`.

3) `npm` has dedicated script `test`, which can be valuable during CI, and just for simplification and usability as developer not to type lot of text. Added alias in package.json. 
*But FYI*: for running `node test/test.js` u need to install requirejs locally, because global is not accessible. In regards to this small note, I may create separate PR later.

4) `bower.json` has not valid structure, which cause warning during any bower activity:
```
bower invalid-meta for:/Users/alund/prj/require-css/bower.json
bower invalid-meta The "main" field has to contain only 1 file per filetype; found multiple .js files: ["css.js","css-builder.js","normalize.js"]
```
So I changed to be only `css.js`

5) I personally like to use tab spacing, but I see, that majority of code is indented by using 2 spaces. So I added `.editorconfig` and `.jsbeautifyrc` which will prevent from wrong indentation. Also in future, I will create grunt task for auto-jsbeautify before commit.