### PR TITLE
'Support both csso v1 and v2' - Improved code in handling csso optimization function (justDoIt vs. minify)

### DIFF
--- a/compatibility-test.sh
+++ b/compatibility-test.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# To cover all possible use case, you should change `optimizeCss` in `example/build.js` from "none" to
+# optimizeCss: "standard.keepLines"
+# optimizeCss: "standard.keepWhitespace"
+# optimizeCss: "standard.keepComments"
+# optimizeCss: "standard.keepComments.keepLines"
+# optimizeCss: "standard.keepLines.keepWhitespace" - default by r.js
+
+(
+  npm install requirejs@2.1.10 -g
+
+  npm install csso@1.3.12 -g
+  r.js -o example/build.js
+
+  npm install csso@1.4.0 -g
+  r.js -o example/build.js
+
+  npm install csso@1.8.0 -g
+  r.js -o example/build.js
+
+  npm install csso@2.0.0 -g
+  r.js -o example/build.js
+
+  npm install csso@latest -g
+  r.js -o example/build.js
+
+  # RequireJS@latest
+
+  npm install requirejs@latest -g
+
+  npm install csso@1.3.12 -g
+  r.js -o example/build.js
+
+  npm install csso@1.4.0 -g
+  r.js -o example/build.js
+
+  npm install csso@1.8.0 -g
+  r.js -o example/build.js
+
+  npm install csso@2.0.0 -g
+  r.js -o example/build.js
+
+  npm install csso@latest -g
+  r.js -o example/build.js
+) > compatibility.log

--- a/css-builder.js
+++ b/css-builder.js
@@ -18,7 +18,16 @@ define(['require', './normalize'], function(req, normalize) {
       }
       var csslen = css.length;
       try {
-        css =  csso.justDoIt(css);
+        if (typeof csso.minify === 'function') {
+            var minifyResult = csso.minify(css);
+            if (typeof minifyResult === 'string'){ // for csso < 2.0.0
+              css = minifyResult; 
+            } else if (typeof minifyResult === 'object'){ // for csso >= 2.0.0
+              css = minifyResult.css; 
+            } 
+        } else { // justDoIt() was always. minify() appeared in csso 1.4.0.
+          css = csso.justDoIt(css);
+        }
       }
       catch(e) {
         console.log('Compression failed due to a CSS syntax error.');


### PR DESCRIPTION
`csso` releases review: 
- since 1.4.0 we have minify() and earlier (eg. 1.3.12) it was ONLY justDoIt()
- in csso 1.8.0 csso.minify() and csso.justDoIt() both exists and they are functions.
- in csso 2.0.0 and 2.3.1 has no justDoIt() AT ALL.

Tested with:
- require-css `0.1.8` as a base.
- csso `1.3.12`, `1.4.0`, `1.8.0`, `2.0.0` and latest (checked 2017/02/18) `2.3.1`.
- requirejs `2.1.10` and `2.3.2`
- node `6.9.5` + npm `3.10.10`
- node `7.5.2` + npm `4.1.2`
- command `r.js -o example/build.js` with all possible values for `optimizeCss`

Compatibility Note: I realize, this change may be overthinking/overcomplex, but so far the fact is - there are end consumers of `require-css` who will upgrade to new `require-css` version, but remain old `csso` version `--global`or as in my enterprise case (locally in project). 
They will have errors like I mentioned in this PR and in #203 and #219.  


## A bit of automation :) in this boring life
1) In scope of this PR, I added `compatibility-test.sh`.
2) To use this script, you should change `optimizeCss` in `example/build.js`file from `"none"`to 
- `optimizeCss: "standard.keepLines"`
- `optimizeCss: "standard.keepWhitespace"`
- `optimizeCss: "standard.keepComments"`
- `optimizeCss: "standard.keepComments.keepLines"`
- `optimizeCss: "standard.keepLines.keepWhitespace"` - default by `r.js`
3) At every execution time, script file generates `compatibility.log`. By searching value `Compressed CSS output` in that log file, u should see always all good, no Syntax Errors. Active for Feb-19-2017.


cc/ @guybedford  @prantlf 