### PR TITLE
Recreated PR: Changed url pattern in normalize.js. Tests passed.

### DIFF
--- a/example/build.js
+++ b/example/build.js
@@ -2,7 +2,7 @@
   appDir: 'www',
   dir: 'www-built',
   baseUrl: '.',
-  fileExclusionRegExp: /(^example)|(.git)|(node_modules)|(bower_components)$/,
+  fileExclusionRegExp: /(^example)|(.git)|(node_modules)|(bower_components)|(test)$/,
   //separateCSS: true,
   //buildCSS: false,
   optimizeCss: "none",

--- a/example/test.html
+++ b/example/test.html
@@ -23,6 +23,6 @@
     var div = document.createElement('div');
     div.innerHTML = popupHTML;
     document.body.appendChild(div);
-    alert(div.childNodes[0].offsetWidth == 340 ? 'Style query passed' : 'Style query failed');
+    console.log(div.childNodes[0].offsetWidth == 340 ? 'Style query passed' : 'Style query failed');
   });
 </script>

--- a/example/www/style/style.css
+++ b/example/www/style/style.css
@@ -1,6 +1,6 @@
 /* module.css */
 /* used by app.js */
-@import '/test.css'
+@import url('/test.css');
 body {
   font-family: sans-serif;
 }

--- a/example/www/test.html
+++ b/example/www/test.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <html>
+<head>
 <script type='text/javascript' src='../../../require.js'></script>
 <script>
   require.config({
@@ -10,11 +11,9 @@
     }
   });
 </script>
-
+</head>
 <body>
 <h1>test</h1>
-</body>
-
 
 <script>
   require(['app'], function(){});
@@ -22,6 +21,9 @@
     var div = document.createElement('div');
     div.innerHTML = popupHTML;
     document.body.appendChild(div);
-    alert(div.childNodes[0].offsetWidth == 340 ? 'Style query passed' : 'Style query failed');
+    console.log(div.childNodes[0].offsetWidth == 340 ? 'Style query passed' : 'Style query failed');
   });
 </script>
+
+</body>
+</html>

--- a/normalize.js
+++ b/normalize.js
@@ -129,7 +129,7 @@ define(function() {
 
   var normalizeCSS = function(source, fromBase, toBase) {
 
-    var urlRegEx = /@import\s*("([^"]*)"|'([^']*)')|url\s*\((?!#)\s*(\s*"([^"]*)"|'([^']*)'|[^\)]*\s*)\s*\)/ig;
+    var urlRegEx = /@import\s*((?:"([^"]*)")|(?:'([^']*)'))|url\s*\(\s*(\s*(?:"([^"]*)")|(?:'([^']*)')|[^\)]*\s*)\s*\)/ig;
     var result, url, source;
 
     while (result = urlRegEx.exec(source)) {

--- a/package.json
+++ b/package.json
@@ -6,5 +6,10 @@
   },
   "scripts": {
     "test": "node test/test.js"
-  }
+  },
+  "devDependencies": {
+    "requirejs": "2.1.10"
+  },
+  "repository": "https://github.com/guybedford/require-css",
+  "license": "MIT"
 }

--- a/test/test.js
+++ b/test/test.js
@@ -52,11 +52,17 @@ requirejs(['../css', '../normalize'], function(css, normalize) {
     normalize.convertURIBase('url(../test)', '/one/two/../three', '/one/four'),
     'url(../test)'
   );
+
   console.log('\nTesting Stylesheet Regular Expressions');
   assert(
     '@import statements',
     normalize('@import "test.css"', '/first/', '/second/'),
     '@import "../first/test.css"'
+  );
+  assert(
+    '@import statements with url()',
+    normalize('@import url("test.css")', '/first/', '/second/'),
+    '@import url("../first/test.css")'
   );
   assert(
     'url includes',
@@ -74,7 +80,7 @@ requirejs(['../css', '../normalize'], function(css, normalize) {
     '//font.server.com/static/fonts/opensans.woff'
   );
   assert(
-    'absolute url convert base',
+    'absolute url convert base (http)',
     normalize.convertURIBase("http://font.server.com/static/fonts/opensans.woff", '/first/one/', '/second/one/'),
     'http://font.server.com/static/fonts/opensans.woff'
   );
@@ -82,6 +88,11 @@ requirejs(['../css', '../normalize'], function(css, normalize) {
     'multiple url includes on the same line',
     normalize('src: url("../fonts/font.eot") format("embedded-opentype"), url("../fonts/font.woff") format("woff");', '/base/', '/'),
     'src: url("fonts/font.eot") format("embedded-opentype"), url("fonts/font.woff") format("woff");'
+  );
+  assert(
+    'multiple url includes on the same line (mixed)',
+    normalize('src: url("../fonts/font.eot") format("embedded-opentype"), url("http://server.com/opensans.woff") format("woff");', '/base/', '/'),
+    'src: url("fonts/font.eot") format("embedded-opentype"), url("http://server.com/opensans.woff") format("woff");'
   );
   assert(
     'absolute URI test',


### PR DESCRIPTION
I recreated PR, with changes from https://github.com/guybedford/require-css/pull/97 PR.

Decided to choose @dataway variant, but I agree with @fearphage there is for sure simplified version. And we will work it later.

Here is screenshot of RegExr.com, how pattern works:

<img width="987" alt="screen shot 2017-02-19 at 17 45 40" src="https://cloud.githubusercontent.com/assets/2131633/23104312/9a18c1a4-f6cb-11e6-8d7b-f0a5611172ce.png">

During this PR, I added 2 new test cases:

```
assert(
    '@import statements with url()',
    normalize('@import url("test.css")', '/first/', '/second/'),
    '@import url("../first/test.css")'
);
// so that to test combination of @import and url()

assert(
    'multiple url includes on the same line (mixed)',
    normalize('src: url("../fonts/font.eot") format("embedded-opentype"), url("http://server.com/opensans.woff") format("woff");', '/base/', '/'),
    'src: url("fonts/font.eot") format("embedded-opentype"), url("http://server.com/opensans.woff") format("woff");'
);
// so that to test combination of absolute and protocol-based urls.
```
Her is `test` results:
```
--- Starting Require CSS Tests ---

Testing URL Base Conversions
  Changing subfolder... passed.
  Changing subfolder with backtrack... passed.
  Changing two subfolders with a folder... passed.
  Double forward slashes in relative URI... passed.
  protocol base urls work... passed.
  absolute protocol paths work with base conversion... passed.
  Converting with backtrack in fromBase... passed.

Testing Stylesheet Regular Expressions
  @import statements... passed.
  @import statements with url()... passed.
  url includes... passed.
  absolute url detection... passed.
  absolute url convert base... passed.
  absolute url convert base (http)... passed.
  multiple url includes on the same line... passed.
  multiple url includes on the same line (mixed)... passed.
  absolute URI test... passed.

--- Require CSS Tests Complete: 16 passed, 0 failed. ---
```


In scope of this PR, I also added `requirejs` to devDependencies, because it's needed by command `node test/test.js` aliased as `npm test` (from previous commits). Yes, I know, there is `require-css/test/maxStylesTest/lib/require.js` and I know it's the same version `2.1.10`. And I did it on purpose. So far, I can't dramatically change lot of things I see in `require-css` module, but I will do it step-by-step.

