### PR TITLE
fix css-builder in node 6 or higher when config.dir is undefined

### DIFF
--- a/css-builder.js
+++ b/css-builder.js
@@ -127,7 +127,7 @@ define(['require', './normalize'], function(req, normalize) {
     config = config || _config;
 
     if (!siteRoot) {
-      siteRoot = path.resolve(config.dir || path.dirname(config.out), config.siteRoot || '.') + '/';
+        siteRoot = path.resolve(config.dir || (typeof config.out === 'string' && path.dirname(config.out)) || '', config.siteRoot || '.') + '/';
       if (isWindows)
         siteRoot = siteRoot.replace(/\\/g, '/');
     }


### PR DESCRIPTION
In node 6 or higher if path.dirname not receipt a string, throw a exception.
https://nodejs.org/dist/latest-v6.x/docs/api/path.html#path_path_dirname_path