### PR TITLE
Don't break on updated Rjs `out` functionality

### DIFF
--- a/css-builder.js
+++ b/css-builder.js
@@ -127,7 +127,7 @@ define(['require', './normalize'], function(req, normalize) {
     config = config || _config;
 
     if (!siteRoot) {
-      siteRoot = path.resolve(config.dir || path.dirname(config.out), config.siteRoot || '.') + '/';
+      siteRoot = path.resolve(config.dir || path.dirname(typeof config.out === 'string' ? config.out : config.out.toString()), config.siteRoot || '.') + '/';
       if (isWindows)
         siteRoot = siteRoot.replace(/\\/g, '/');
     }


### PR DESCRIPTION
Resolves: https://github.com/guybedford/require-css/issues/231, https://github.com/guybedford/require-css/issues/229

With new Rjs, `out` can be a function (https://github.com/requirejs/r.js/blob/master/build/example.build.js#L448). Need to support dealing with `out` as being a function. In this case, simply checking if the property is a string, and if not, `toString`-ing it will allow the `siteRoot` to be determined correctly.